### PR TITLE
Add required labels to selectable d2l-list-items.

### DIFF
--- a/src/components/add-videos-dialog.js
+++ b/src/components/add-videos-dialog.js
@@ -124,7 +124,7 @@ class D2lCaptureAddVideosDialog extends contentSearchMixin(DependencyRequester(I
 		}
 		const videos = this._videos.map(({ thumbnail, title, uploadDate, duration, views }) => {
 			return html`
-				<d2l-list-item class="d2l-capture-central-video-list-item" selectable key="${views}">
+				<d2l-list-item class="d2l-capture-central-video-list-item" selectable label="${title}" key="${views}">
 					<div slot="illustration">
 						<img alt="" class="d2l-capture-central-video-thumbnail" src="${thumbnail}" slot="illustration"></img>
 						<div class="d2l-capture-central-video-thumbnail-duration-overlay">

--- a/src/components/my-videos/content-list-item.js
+++ b/src/components/my-videos/content-list-item.js
@@ -70,6 +70,7 @@ class ContentListItem extends DependencyRequester(navigationMixin(InternalLocali
 		return html`
 			<d2l-list-item class="d2l-body-compact"
 				?disabled=${this.disabled}
+				label="${this.title}"
 				?selectable=${this.selectable}
 				key=${this.id}
 			>


### PR DESCRIPTION
This PR adds labels to selectable d2l-list-items that will be required in the near future in order to support changes that are being made to lists for selection, multi-selection, and multi-actions.